### PR TITLE
fp group elts thread safety

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Groups"
 uuid = "5d8bd718-bd84-11e8-3b40-ad14f4a32557"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>"]
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"

--- a/src/wl_ball.jl
+++ b/src/wl_ball.jl
@@ -34,7 +34,8 @@ function _wlmetric_ball(S, old, radius, op, collect, unique)
     for r in 2:radius
         old = let old = old, S = S,
             new = collect(
-                (g = op(o, s); hash(g); g)
+                (g = op(o, s); normalform!(g); hash(g); g)
+                # normalform! and hash are to make assure thread-safety of produced elts
                 for o in @view(old[sizes[end-1]:end]) for s in S
             )
 


### PR DESCRIPTION
`wl_metricball` may have tendency to segfault since the produced elements are not thread-safe. This is an attempt to fix this by pre-computing normalforms as we go.

now `wl_metricball` for `radius=4` seems to finish just fine (at least for `SAut(F_5)`), but there are some more crashes while computing `WedderburnDecomposition`...